### PR TITLE
bump nom to 7.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "hdd"
 description = "hdd: instruments for querying ATA and SCSI disks"
-version = "0.10.0"
+version = "0.10.3"
 authors = ["vthriller <unixway.drive+rs@gmail.com>"]
 repository = "https://github.com/vthriller/hdd-rs"
 license = "MPL-2.0"
@@ -12,7 +12,7 @@ members = ["sample-scsi", "drivedb-bench"]
 
 [dependencies]
 libc = "0.2"
-nom = "^2.2"
+nom = "7.1.3"
 regex = "0.2"
 byteorder = "1"
 quick-error = "1.2"

--- a/src/drivedb/loader.rs
+++ b/src/drivedb/loader.rs
@@ -2,39 +2,40 @@ use super::parser::{self, Entry};
 use super::DriveDB;
 
 use std::fs::File;
-use std::io::prelude::*;
 use std::io;
+use std::io::prelude::*;
 
 use nom;
 
 use regex; // for Loader.db() error type
 
 quick_error! {
-	#[derive(Debug)]
-	pub enum Error {
-		IO(err: io::Error) {
-			from()
-			display("IO error: {}", err)
-			description(err.description())
-			cause(err)
-		}
-		Parse {
-			// TODO? Parse(nom::verbose_errors::Err) if dependencies.nom.features = ["verbose-errors"]
-			display("Unable to parse the drivedb")
-			description("malformed database")
-		}
-	}
+    #[derive(Debug)]
+    pub enum Error {
+        IO(err: io::Error) {
+            from()
+            display("IO error: {}", err)
+            description(err.description())
+            cause(err)
+        }
+        Parse {
+            // TODO? Parse(nom::verbose_errors::Err) if dependencies.nom.features = ["verbose-errors"]
+            display("Unable to parse the drivedb")
+            description("malformed database")
+        }
+    }
 }
 
 fn load(file: &str) -> Result<Vec<Entry>, Error> {
-	let mut db = Vec::new();
-	File::open(&file)?.read_to_end(&mut db)?;
+    let mut db = Vec::new();
+    File::open(&file)?.read_to_end(&mut db)?;
 
-	match parser::database(&db) {
-		nom::IResult::Done(_, entries) => Ok(entries),
-		nom::IResult::Error(_) => Err(Error::Parse),
-		nom::IResult::Incomplete(_) => unreachable!(), // XXX is it true?
-	}
+    match parser::database(&db) {
+        Ok((_, entries)) => Ok(entries),
+        Err(nom::Err::Error(_)) => Err(Error::Parse),
+        Err(nom::Err::Incomplete(_)) => unreachable!(), // XXX is it true?
+        Err(nom::Err::Failure(_)) => todo!(),
+    }
 }
 
 /**
@@ -44,52 +45,54 @@ It is also possible to use `Loader` to create dummy database in case if only use
 */
 #[derive(Debug)]
 pub struct Loader {
-	entries: Vec<Entry>,
-	additional: Vec<Entry>,
+    entries: Vec<Entry>,
+    additional: Vec<Entry>,
 }
 impl Loader {
-	pub fn new() -> Self {
-		Loader {
-			entries: vec![],
-			additional: vec![],
-		}
-	}
-	/**
-	Loads entries from main drivedb file.
+    pub fn new() -> Self {
+        Loader {
+            entries: vec![],
+            additional: vec![],
+        }
+    }
+    /**
+    Loads entries from main drivedb file.
 
-	Entries from previously loaded main file will be discarded; entries from additional files will not be affected.
+    Entries from previously loaded main file will be discarded; entries from additional files will not be affected.
 
-	## Errors
+    ## Errors
 
-	Returns [enum Error](enum.Error.html) if:
+    Returns [enum Error](enum.Error.html) if:
 
-	- it encounters any kind of I/O error,
-	- drive database is malformed.
-	*/
-	pub fn load(&mut self, file: &str) -> Result<(), Error> {
-		self.entries = load(file)?;
-		Ok(())
-	}
-	/**
-	Loads more entries from additional drivedb file. Additional entries always take precedence over the ones from the main file.
+    - it encounters any kind of I/O error,
+    - drive database is malformed.
+    */
+    pub fn load(&mut self, file: &str) -> Result<(), Error> {
+        self.entries = load(file)?;
+        Ok(())
+    }
+    /**
+    Loads more entries from additional drivedb file. Additional entries always take precedence over the ones from the main file.
 
-	## Errors
+    ## Errors
 
-	Returns [enum Error](enum.Error.html) if:
+    Returns [enum Error](enum.Error.html) if:
 
-	- it encounters any kind of I/O error,
-	- drive database is malformed.
-	*/
-	pub fn load_additional(&mut self, file: &str) -> Result<(), Error> {
-		self.entries = load(file)?;
-		Ok(())
-	}
-	/// Returns actual drive database with all entries loaded beforehand.
-	pub fn db(self) -> Result<DriveDB, regex::Error> {
-		let entries: Vec<_> = self.additional.into_iter()
-			.chain(self.entries.into_iter())
-			.collect();
+    - it encounters any kind of I/O error,
+    - drive database is malformed.
+    */
+    pub fn load_additional(&mut self, file: &str) -> Result<(), Error> {
+        self.entries = load(file)?;
+        Ok(())
+    }
+    /// Returns actual drive database with all entries loaded beforehand.
+    pub fn db(self) -> Result<DriveDB, regex::Error> {
+        let entries: Vec<_> = self
+            .additional
+            .into_iter()
+            .chain(self.entries.into_iter())
+            .collect();
 
-		DriveDB::new(entries)
-	}
+        DriveDB::new(entries)
+    }
 }

--- a/src/drivedb/vendor_attribute.rs
+++ b/src/drivedb/vendor_attribute.rs
@@ -10,101 +10,111 @@ Format for attribute descriptions is described in [smartctl(8)](https://www.smar
 */
 use std::str;
 
-use nom;
-use nom::digit;
+use nom::{
+    branch::alt,
+    bytes::complete::{tag, take_till1},
+    character::complete::{char, digit1},
+    combinator::{complete, eof, map, map_res, opt, value},
+    sequence::preceded,
+    IResult,
+};
 
 quick_error! {
-	#[derive(Debug)]
-	pub enum Error {
-		Parse {
-			// TODO? Parse(nom::verbose_errors::Err) if dependencies.nom.features = ["verbose-errors"]
-			display("Unable to parse vendor attribute")
-		}
-	}
+    #[derive(Debug)]
+    pub enum Error {
+        Parse {
+            // TODO? Parse(nom::verbose_errors::Err) if dependencies.nom.features = ["verbose-errors"]
+            display("Unable to parse vendor attribute")
+        }
+    }
 }
 
 /// HDD or SSD
 #[derive(Debug, Clone, Copy, PartialEq)]
-pub enum Type { HDD, SSD }
+pub enum Type {
+    HDD,
+    SSD,
+}
 
 /// SMART attribute description
 #[derive(Debug, Clone)]
 pub struct Attribute {
-	/// id of described attribute
-	pub id: Option<u8>,
-	/// attribute name
-	pub name: Option<String>,
-	/// value format, like `raw48` or `tempminmax`
-	pub format: String,
-	/// bytes of attribute data to make value of (usually something like `r543210`, where `r`, `v`, `w` represent reserved byte, current and worst values respectively)
-	pub byte_order: String,
-	/// what kind of device this description is applicable to: HDD, SSD, or both
-	pub drivetype: Option<Type>,
+    /// id of described attribute
+    pub id: Option<u8>,
+    /// attribute name
+    pub name: Option<String>,
+    /// value format, like `raw48` or `tempminmax`
+    pub format: String,
+    /// bytes of attribute data to make value of (usually something like `r543210`, where `r`, `v`, `w` represent reserved byte, current and worst values respectively)
+    pub byte_order: String,
+    /// what kind of device this description is applicable to: HDD, SSD, or both
+    pub drivetype: Option<Type>,
 }
 
-fn not_comma(c: u8) -> bool { c == b',' }
-fn not_comma_nor_colon(c: u8) -> bool { c == b',' || c == b':' }
+fn not_comma(c: u8) -> bool {
+    c == b','
+}
+fn not_comma_nor_colon(c: u8) -> bool {
+    c == b',' || c == b':'
+}
 
 // `opt!()` is used with `complete!()` here because the former returns `Incomplete` untouched, thus making attributes not ending with otherwise optional ',(HDD|SSD)' `Incomplete` as well.
-named!(parse_standard <Attribute>, do_parse!(
-	id: alt!(
-		// XXX map_res!()?
-		map!(digit, |x: &[u8]| str::from_utf8(x).unwrap().parse::<u8>().ok())
-		// > If 'N' is specified as ID, the settings for all Attributes are changed
-		| do_parse!(char!('N') >> (None))
-	) >>
-	char!(',') >>
-	format: map_res!(
-		take_till1_s!(not_comma_nor_colon),
-		str::from_utf8
-	) >>
-	// TODO '+' for ATTRFLAG_INCREASING
-	byte_order: opt!(complete!(do_parse!( // TODO len()<6 should be invalid
-		char!(':') >>
-		byteorder: map_res!(
-			take_till1_s!(not_comma),
-			str::from_utf8
-		) >>
-		(byteorder)
-	))) >>
-	name_drive_type: opt!(complete!(do_parse!(
-		char!(',') >>
-		name: map_res!(
-			take_till1_s!(not_comma),
-			str::from_utf8
-		) >>
-		drive_type: opt!(complete!(do_parse!(
-			char!(',') >>
-			drive_type: alt!(tag!("HDD") | tag!("SSD")) >>
-			(match str::from_utf8(drive_type) {
-				Ok("HDD") => Type::HDD,
-				Ok("SSD") => Type::SSD,
-				_ => unreachable!(),
-			})
-		))) >>
-		(name, drive_type)
-	))) >>
-	eof!() >>
-	({
-		let (name, drive_type) = match name_drive_type {
-			Some((name, drive_type)) => (Some(name), drive_type),
-			None => (None, None),
-		};
-		let default_byte_order = match format {
-			// default byte orders, from ata_get_attr_raw_value, atacmds.cpp
-			"raw64" | "hex64" => "543210wv",
-			"raw56" | "hex56" | "raw24/raw32" | "msec24hour32" => "r543210",
-			_ => "543210",
-		};
-		Attribute {
-			id: id,
-			name: name.map(|x| x.to_string()),
-			format: format.to_string(),
-			byte_order: byte_order.unwrap_or(default_byte_order).to_string(),
-			drivetype: drive_type,
-		}
-	})
-));
+fn parse_standard(i: &[u8]) -> IResult<&[u8], Attribute> {
+    let (i, id) = alt((
+        // XXX map_res!()?
+        map(digit1, |x: &[u8]| {
+            str::from_utf8(x).unwrap().parse::<u8>().ok()
+        }),
+        value(None, char('N')),
+    ))(i)?;
+
+    let (i, _) = char(',')(i)?;
+    let (i, format) = map_res(take_till1(not_comma_nor_colon), str::from_utf8)(i)?;
+    // TODO '+' for ATTRFLAG_INCREASING
+    let (i, byte_order) = opt(complete(preceded(
+        char(':'),
+        // TODO len()<6 should be invalid
+        map_res(take_till1(not_comma), str::from_utf8),
+    )))(i)?;
+
+    fn parse_name_drive_type(i: &[u8]) -> IResult<&[u8], (&str, Option<Type>)> {
+        let (i, _) = char(',')(i)?;
+        let (i, name) = map_res(take_till1(not_comma), str::from_utf8)(i)?;
+        let (i, drive_type) = opt(complete(map(
+            preceded(char(','), alt((tag("HDD"), tag("SSD")))),
+            |drive_type| match str::from_utf8(drive_type) {
+                Ok("HDD") => Type::HDD,
+                Ok("SSD") => Type::SSD,
+                _ => unreachable!(),
+            },
+        )))(i)?;
+
+        Ok((i, (name, drive_type)))
+    }
+    let (i, name_drive_type) = opt(complete(parse_name_drive_type))(i)?;
+    let (i, _) = eof(i)?;
+
+    let (name, drive_type) = match name_drive_type {
+        Some((name, drive_type)) => (Some(name), drive_type),
+        None => (None, None),
+    };
+    let default_byte_order = match format {
+        // default byte orders, from ata_get_attr_raw_value, atacmds.cpp
+        "raw64" | "hex64" => "543210wv",
+        "raw56" | "hex56" | "raw24/raw32" | "msec24hour32" => "r543210",
+        _ => "543210",
+    };
+    Ok((
+        i,
+        Attribute {
+            id: id,
+            name: name.map(|x| x.to_string()),
+            format: format.to_string(),
+            byte_order: byte_order.unwrap_or(default_byte_order).to_string(),
+            drivetype: drive_type,
+        },
+    ))
+}
 
 /**
 Parses single attribute description (`-v` option argument).
@@ -115,27 +125,28 @@ The following formats are supported:
 * legacy `-v` arguments, like `9,halfminutes`
 */
 pub fn parse(s: &str) -> Result<Attribute, Error> {
-	let s = match s {
-		"9,halfminutes" => "9,halfmin2hour,Power_On_Half_Minutes",
-		"9,minutes" => "9,min2hour,Power_On_Minutes",
-		"9,seconds" => "9,sec2hour,Power_On_Seconds",
-		"9,temp" => "9,tempminmax,Temperature_Celsius",
-		"192,emergencyretractcyclect" => "192,raw48,Emerg_Retract_Cycle_Ct",
-		"193,loadunload" => "193,raw24/raw24",
-		"194,10xCelsius" => "194,temp10x,Temperature_Celsius_x10",
-		"194,unknown" => "194,raw48,Unknown_Attribute",
-		"197,increasing" => "197,raw48+,Total_Pending_Sectors",
-		"198,offlinescanuncsectorct" => "198,raw48,Offline_Scan_UNC_SectCt", // TODO? there goes some `get_unc_attr_id` reference
-		"198,increasing" => "198,raw48+,Total_Offl_Uncorrectabl",
-		"200,writeerrorcount" => "200,raw48,Write_Error_Count",
-		"201,detectedtacount" => "201,raw48,Detected_TA_Count",
-		"220,temp" => "220,tempminmax,Temperature_Celsius",
-		s => s,
-	};
-	// FIXME strings to bytes to strings again… sounds really stupid
-	match parse_standard(s.as_bytes()) {
-		nom::IResult::Done(_, attr) => Ok(attr),
-		nom::IResult::Error(_) => Err(Error::Parse), // TODO?
-		nom::IResult::Incomplete(_) => Err(Error::Parse), // TODO?
-	}
+    let s = match s {
+        "9,halfminutes" => "9,halfmin2hour,Power_On_Half_Minutes",
+        "9,minutes" => "9,min2hour,Power_On_Minutes",
+        "9,seconds" => "9,sec2hour,Power_On_Seconds",
+        "9,temp" => "9,tempminmax,Temperature_Celsius",
+        "192,emergencyretractcyclect" => "192,raw48,Emerg_Retract_Cycle_Ct",
+        "193,loadunload" => "193,raw24/raw24",
+        "194,10xCelsius" => "194,temp10x,Temperature_Celsius_x10",
+        "194,unknown" => "194,raw48,Unknown_Attribute",
+        "197,increasing" => "197,raw48+,Total_Pending_Sectors",
+        "198,offlinescanuncsectorct" => "198,raw48,Offline_Scan_UNC_SectCt", // TODO? there goes some `get_unc_attr_id` reference
+        "198,increasing" => "198,raw48+,Total_Offl_Uncorrectabl",
+        "200,writeerrorcount" => "200,raw48,Write_Error_Count",
+        "201,detectedtacount" => "201,raw48,Detected_TA_Count",
+        "220,temp" => "220,tempminmax,Temperature_Celsius",
+        s => s,
+    };
+    // FIXME strings to bytes to strings again… sounds really stupid
+    match parse_standard(s.as_bytes()) {
+        Ok((_, attr)) => Ok(attr),
+        Err(nom::Err::Error(_)) => Err(Error::Parse), // TODO?
+        Err(nom::Err::Incomplete(_)) => Err(Error::Parse), // TODO?
+        Err(nom::Err::Failure(_)) => todo!(),         // TODO?
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,21 +31,20 @@ For more, dive into documentation for the module you're interested in.
 	unused_import_braces,
 	unused_qualifications,
 )]
-
 /* XXX
 This lint is here mainly to prevent trait gate method hack from becoming recursive. E.g.:
 
 ```
 impl Foo<Bar> {
-	pub fn foo() {}
+    pub fn foo() {}
 }
 
 impl Foo<Baz> {
-	pub fn foo() {}
+    pub fn foo() {}
 }
 
 impl<T> Whatever for Foo<T> {
-	fn foo() { Self::foo() }
+    fn foo() { Self::foo() }
 }
 ```
 
@@ -63,16 +62,20 @@ extern crate quick_error;
 #[macro_use]
 extern crate log;
 
-#[macro_use]
+extern crate byteorder;
 extern crate nom;
 extern crate regex;
-extern crate byteorder;
 
 extern crate libc;
 
 /// Data transfer direction
 #[derive(Debug, Clone, Copy)]
-pub enum Direction { None, From, To, Both }
+pub enum Direction {
+    None,
+    From,
+    To,
+    Both,
+}
 
 pub mod device;
 pub use device::*;


### PR DESCRIPTION
This fixes a warning telling us nom is about to be imcompatible with future rust versions:
```
the following packages contain code that will be rejected by a future version of Rust: nom v2.2.1
```